### PR TITLE
Typo: setTaxiLight -> setTaxiLights, Add mp.game.vehicle.defaultEngineBehaviour

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1328,7 +1328,7 @@ interface VehicleMp extends EntityMp {
 	setSiren(toggle: boolean): void;
 	setSteerBias(value: number): void;
 	setStrong(toggle: boolean): void;
-	setTaxiLight(state: boolean): void;
+	setTaxiLights(state: boolean): void;
 	setTimedExplosion(ped: Handle, toggle: boolean): void;
 	setTowTruckCraneHeight(height: number): void;
 	setTrainCruiseSpeed(speed: number): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -3084,6 +3084,7 @@ interface GameVehicleMp {
 	stopPlaybackRecordedVehicle(p0: any): void;
 	switchTrainTrack(intersectionId: number, state: boolean): any;
 	unpausePlaybackRecordedVehicle(p0: any): void;
+	defaultEngineBehaviour: boolean;
 }
 
 interface GameWaterMp {


### PR DESCRIPTION
Typo: https://wiki.rage.mp/index.php?title=Vehicle::setTaxiLights

defaultEngineBehaviour: https://discordapp.com/channels/183979885788659713/502927676101885999/523912383396315147
(When true, player doesn't turn engine automatically on)