### PR TITLE
Change signatures of functions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3296,8 +3296,7 @@ interface ObjectMpPool extends EntityMpPool<ObjectMp> {
 }
 
 interface PedMpPool extends EntityMpPool<PedMp> {
-	"new"(model: RageEnums.Hashes.Ped | Hash, position: Vector3Mp, heading: number,
-		streamInEventHandler?: (ped: PedMp) => void, dimension?: number): PedMp;
+	"new"(model: RageEnums.Hashes.Ped | Hash, position: Vector3Mp, heading: number, dimension?: number): PedMp;
 }
 
 interface PickupMpPool extends EntityMpPool<PickupMp> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -354,6 +354,8 @@ interface ObjectMp extends EntityMp {
 
 interface PedMp extends EntityMp {
 	spawnPosition: Vector3Mp;
+	taskPlayAnim(animDictionary: string, animationName: string, speed: number, speedMultiplier: number, duration: number,
+		flag: number, playbackRate: number, lockX: boolean, lockY: boolean, lockZ: boolean): void;
 	// TODO
 }
 


### PR DESCRIPTION
This PR removes the stream in event from the method signature, because this was an invalid wrapper for the `mp.peds.new(model, position, heading, dimension);` method of the JS API (see https://wiki.rage.mp/index.php?title=Peds::new for instance).

Furthermore, this PR adds the `taskPlayAnim` method to the `PedMp` interface.

Beyond that, we should ask the RageMP administration for a documentation of **all** valid JS endpoints, to complete this project for the moment.