### PR TITLE
Adds mp.game.gxt

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -83,6 +83,7 @@ interface GameMp {
 	weapon: GameWeaponMp;
 	worldprobe: GameWorldprobeMp;
 	zone: GameZoneMp;
+	gxt: GameGxtMp;
 
 	invoke(hash: string, ...args: any[]): any;
 	joaat(text: string): Hash;
@@ -3194,6 +3195,13 @@ interface GameZoneMp {
 	overridePopscheduleVehicleModel(scheduleId: number, vehicleHash: number): void;
 	overridePopscheduleVehicleModel(scheduleId: number, vehicleHash: string): void;
 	setZoneEnabled(zoneId: number, toggle: boolean): void;
+}
+
+interface GameGxtMp {
+	add(labelNameOrHash: HashOrString, newLabelValue:any): void;
+	get(labelNameOrHash: HashOrString): any;
+	getDefault(labelNameOrHash: HashOrString): any;
+	reset(): void;
 }
 
 // -------------------------------------------------------------------------

--- a/index.d.ts
+++ b/index.d.ts
@@ -3198,9 +3198,9 @@ interface GameZoneMp {
 }
 
 interface GameGxtMp {
-	add(labelNameOrHash: HashOrString, newLabelValue:any): void;
-	get(labelNameOrHash: HashOrString): any;
-	getDefault(labelNameOrHash: HashOrString): any;
+	add(labelNameOrHash: HashOrString, newLabelValue:string): void;
+	get(labelNameOrHash: HashOrString): string;
+	getDefault(labelNameOrHash: HashOrString): string;
 	reset(): void;
 }
 


### PR DESCRIPTION
`get` and `getDefault` currently have `any` assigned to them, because I am not sure what those return, I have not gotten around to test it in-depth yet.

Only thing I got to test so far is `mp.game.gxt.add("PM_PAUSE_HDR", "Content");` which would mean the `getDefault` and `get` would return a string, however I am not sure if that is potentially the only type that this can return, so any will do for now.