### PR TITLE
Fix gxt types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3232,9 +3232,9 @@ interface GameZoneMp {
 }
 
 interface GameGxtMp {
-	add(labelNameOrHash: HashOrString, newLabelValue:string): void;
-	get(labelNameOrHash: HashOrString): string;
-	getDefault(labelNameOrHash: HashOrString): string;
+	set(labelNameOrHash: string, newLabelValue:string): void;
+	get(labelNameOrHash: string): string;
+	getDefault(labelNameOrHash: string): string;
 	reset(): void;
 }
 


### PR DESCRIPTION
After some more testing on these, `labelNameOrHash` (although documented like this in the 1.1 thread) actually only takes strings, when passing a hash, it just does not work.

For some reason `add` is back, it is actually `set`.