### PR TITLE
add getClosest to EntityMpPool

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3314,7 +3314,7 @@ interface EntityMpPool<TEntity> {
 	forEachInRange(position: Vector3Mp, range: number, fn: (entity: TEntity) => void): void;
 	forEachInDimension(position: Vector3Mp, range: number, dimension: number, fn: (entity: TEntity) => void): void;
 	forEachInStreamRange(fn: (entity: TEntity) => void): void;
-	getClosest(position: Vector3Mp, amount?:number): Array<TEntity>;
+	getClosest(position: Vector3Mp, amount?:number): TEntity[];
 	toArray(): TEntity[];
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -3314,6 +3314,7 @@ interface EntityMpPool<TEntity> {
 	forEachInRange(position: Vector3Mp, range: number, fn: (entity: TEntity) => void): void;
 	forEachInDimension(position: Vector3Mp, range: number, dimension: number, fn: (entity: TEntity) => void): void;
 	forEachInStreamRange(fn: (entity: TEntity) => void): void;
+	getClosest(position: Vector3Mp, amount?:number): Array<TEntity>;
 	toArray(): TEntity[];
 }
 


### PR DESCRIPTION
1.1 features a new function for clientside entities called `getClosest `, it returns by default the first, closest entity, or takes a second parameter if you want to return multiple.

It returns an array of the entities present, or an empty array if none are present.