### PR TITLE
Fixed the wrong type of unequipEmptyWeapons

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3188,7 +3188,7 @@ interface GameWeaponMp {
 	setFlashLightFadeDistance(distance: number): void;
 	setPedAmmoToDrop(p0: any, p1: any): void;
 	setWeaponObjectTintIndex(weapon: EntityMp, tint: number): void;
-	unequipEmptyWeapons(): void;
+	unequipEmptyWeapons: boolean;
 }
 
 interface GameWorldprobeMp {


### PR DESCRIPTION
This is a new parameter and the change logs do not explicitly specify the type, but it is a Boolean value. This was discussed in Discord https://i.imgur.com/okPprwA.png I also checked this one myself.