### PR TITLE
fix wrong naming of invokeVector3 method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -89,7 +89,7 @@ interface GameMp {
 	invoke(hash: string, ...args: any[]): any;
 	invokeFloat(hash: string, ...args: any[]): any;
 	invokeString(hash: string, ...args: any[]): any;
-	invokeVector(hash: string, ...args: any[]): any;
+	invokeVector3(hash: string, ...args: any[]): any;
 	joaat(text: string): Hash;
 	joaat(textArray: string[]): Hash[];
 	wait(ms: number): void;


### PR DESCRIPTION
**invokeVector** doesn't exist. Its actual name is **invokeVector3**.