### PR TITLE
fix: Added setHeadOverlay method for PedMp

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -928,6 +928,15 @@ interface PedBaseMp extends EntityMp {
 
 interface PedMp extends PedBaseMp {
 	spawnPosition: Vector3Mp;
+	/**
+	 * Set head overlay for ped (does not take values to set the overlay color).
+	 * 
+	 * https://wiki.rage.mp/index.php?title=Player::setHeadOverlay
+	 * @param overlayID ID overlay ranges from 0 to 12.
+	 * @param index Index from 0 to _GET_NUM_OVERLAY_VALUES(overlayID)-1.
+	 * @param opacity Opacity from 0.0 to 1.0.
+	 */
+	setHeadOverlay(overlayID: number, index: number, opacity: number): void;
 }
 
 interface PickupMp extends EntityMp {


### PR DESCRIPTION
I suggest for peds to reassign the definition of the types of the `setHeadOverlay` method, since there is a separate note in the documentation https://wiki.rage.mp/index.php?title=Player::setHeadOverlay specifically for using this method on peds. If you ignore it and continue to use it as a player, the client crashes.

![изображение](https://user-images.githubusercontent.com/57041750/103357682-d6a33e00-4ac4-11eb-99d2-4b552cbe89d4.png)
