### PR TITLE
Workaround dummy entity

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -351,7 +351,17 @@ interface ColshapeMp extends EntityMp {
 }
 
 interface DummyEntityMp {
-	readonly dimension: number;
+	// TODO (temporary solution):
+	// Since this is a very abstract concept, it is not at all a familiar essence, but it has most of its properties.
+	// The easiest option is, of course, to inherit the EntityMpPool interface, but this will add
+	// non-existent methods and parameters associated with the dimension and position.
+	// It is proposed in the future to introduce a more abstract concept than an entity, which will have only an ID, a type and several basic
+	// methods such as deletion, enumeration and transformation into an array. The same goes for the entity pool.
+
+	readonly dummyType: number;
+  readonly id: number;
+  readonly remoteId: number;
+  readonly type: string;
 
 	getVariable(value: string): any;
 }
@@ -3441,8 +3451,20 @@ interface EventMpPool {
 	remove(eventNames: string[]): void;
 }
 
-interface DummyEntityMpPool extends EntityMpPool<DummyEntityMp> {
-	forEachByType(dummyEntityType: number, fn: (entity: DummyEntityMp) => void): void;
+interface DummyEntityMpPool {
+	// TODO (temporary solution, see interface DummyEntityMp).
+
+	readonly length: number;
+	readonly size: number;
+
+	apply(fn: (...args: any[]) => void, ...args: any[]): void;
+	at(index: number): DummyEntityMp;
+	atRemoteId(remoteId: number): DummyEntityMp;
+	exists(entity: DummyEntityMp | number): boolean;
+	forEach(fn: (entity: DummyEntityMp) => void): void;
+	forEachByType(dummyType: number, fn: (entity: DummyEntityMp) => void): void;
+	toArray(): DummyEntityMp[];
+	toArrayFast(): DummyEntityMp[];
 }
 
 interface MarkerMpPool extends EntityMpPool<MarkerMp> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -359,9 +359,9 @@ interface DummyEntityMp {
 	// methods such as deletion, enumeration and transformation into an array. The same goes for the entity pool.
 
 	readonly dummyType: number;
-  readonly id: number;
-  readonly remoteId: number;
-  readonly type: string;
+	readonly id: number;
+	readonly remoteId: number;
+	readonly type: string;
 
 	getVariable(value: string): any;
 }
@@ -938,15 +938,6 @@ interface PedBaseMp extends EntityMp {
 
 interface PedMp extends PedBaseMp {
 	spawnPosition: Vector3Mp;
-	/**
-	 * Set head overlay for ped (does not take values to set the overlay color).
-	 * 
-	 * https://wiki.rage.mp/index.php?title=Player::setHeadOverlay
-	 * @param overlayID ID overlay ranges from 0 to 12.
-	 * @param index Index from 0 to _GET_NUM_OVERLAY_VALUES(overlayID)-1.
-	 * @param opacity Opacity from 0.0 to 1.0.
-	 */
-	setHeadOverlay(overlayID: number, index: number, opacity: number): void;
 }
 
 interface PickupMp extends EntityMp {

--- a/index.d.ts
+++ b/index.d.ts
@@ -3442,7 +3442,7 @@ interface EventMpPool {
 }
 
 interface DummyEntityMpPool extends EntityMpPool<DummyEntityMp> {
-	forEachByType(fn: (dummyEntity: DummyEntityMp) => void): void;
+	forEachByType(dummyEntityType: number, fn: (entity: DummyEntityMp) => void): void;
 }
 
 interface MarkerMpPool extends EntityMpPool<MarkerMp> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -350,7 +350,7 @@ interface ColshapeMp extends EntityMp {
 	triggered: boolean;
 }
 
-interface DummyEntity {
+interface DummyEntityMp {
 	readonly dimension: number;
 
 	getVariable(value: string): any;
@@ -3394,8 +3394,8 @@ interface EventMpPool {
 	add(eventName: RageEnums.EventKey.BROWSER_LOADING_FAILED, callback: (browser: BrowserMp) => void): void;
 	add(eventName: RageEnums.EventKey.CLICK, callback: (x: number, y: number, upOrDown: string, leftOrRight: string, relativeX: number, relativeY: number, worldPosition: Vector3MpLike, hitEntity: number) => void): void;
 	add(eventName: RageEnums.EventKey.CONSOLE_COMMAND, callback: (command: string) => void): void;
-	add(eventName: RageEnums.EventKey.DUMMY_ENTITY_CREATED, callback: (dummyType: number, dummy: DummyEntity) => void): void;
-	add(eventName: RageEnums.EventKey.DUMMY_ENTITY_DESTROYED, callback: (dummyType: number, dummy: DummyEntity) => void): void;
+	add(eventName: RageEnums.EventKey.DUMMY_ENTITY_CREATED, callback: (dummyType: number, dummy: DummyEntityMp) => void): void;
+	add(eventName: RageEnums.EventKey.DUMMY_ENTITY_DESTROYED, callback: (dummyType: number, dummy: DummyEntityMp) => void): void;
 	add(eventName: RageEnums.EventKey.ENTITY_CONTROLLER_CHANGE, callback: (entity: EntityMp, newController: PlayerMp) => void): void;
 	add(eventName: RageEnums.EventKey.ENTITY_CREATED, callback: (entity: EntityMp) => void): void;
 	add(eventName: RageEnums.EventKey.ENTITY_STREAM_IN, callback: (entity: EntityMp) => void): void;
@@ -3441,8 +3441,8 @@ interface EventMpPool {
 	remove(eventNames: string[]): void;
 }
 
-interface DummyEntityMpPool extends EntityMpPool<DummyEntity> {
-	forEachByType(fn: (dummyEntity: DummyEntity) => void): void;
+interface DummyEntityMpPool extends EntityMpPool<DummyEntityMp> {
+	forEachByType(fn: (dummyEntity: DummyEntityMp) => void): void;
 }
 
 interface MarkerMpPool extends EntityMpPool<MarkerMp> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -928,6 +928,15 @@ interface PedBaseMp extends EntityMp {
 
 interface PedMp extends PedBaseMp {
 	spawnPosition: Vector3Mp;
+	/**
+	 * Set head overlay for ped (does not take values to set the overlay color).
+	 * 
+	 * https://wiki.rage.mp/index.php?title=Player::setHeadOverlay
+	 * @param overlayID ID overlay ranges from 0 to 12.
+	 * @param index Index from 0 to _GET_NUM_OVERLAY_VALUES(overlayID)-1.
+	 * @param opacity Opacity from 0.0 to 1.0.
+	 */
+	setHeadOverlay(overlayID: number, index: number, opacity: number): void;
 }
 
 interface PickupMp extends EntityMp {


### PR DESCRIPTION
Moved to https://github.com/CocaColaBear/types-ragemp-c/pull/70 because the undone changes hit `setHeadOverlay` from https://github.com/CocaColaBear/types-ragemp-c/pull/68.