### PR TITLE
fixed wrong parameters types in getLightsState, testPointToPoint, testCapsule

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1524,8 +1524,8 @@ interface NametagsMp {
 }
 
 interface RaycastingMp {
-	testPointToPoint(startPos: Vector3Mp, endPos: Vector3Mp, ignoreEntity?: Handle, flags?: number): RaycastResult; // TODO: ignoreEntity
-	testCapsule(startPos: Vector3Mp, endPos: Vector3Mp, radius: number, ignoreEntity?: Handle, flags?: number[]): RaycastResult; // TODO: ignoreEntity
+	testPointToPoint(startPos: Vector3Mp, endPos: Vector3Mp, ignoreEntity?: EntityMp, flags?: number): RaycastResult; // TODO: ignoreEntity
+	testCapsule(startPos: Vector3Mp, endPos: Vector3Mp, radius: number, ignoreEntity?: EntityMp, flags?: number[]): RaycastResult; // TODO: ignoreEntity
 }
 
 interface StorageMp {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1524,8 +1524,8 @@ interface NametagsMp {
 }
 
 interface RaycastingMp {
-	testPointToPoint(startPos: Vector3Mp, endPos: Vector3Mp, ignoreEntity?: EntityMp, flags?: number): RaycastResult; // TODO: ignoreEntity
-	testCapsule(startPos: Vector3Mp, endPos: Vector3Mp, radius: number, ignoreEntity?: EntityMp, flags?: number[]): RaycastResult; // TODO: ignoreEntity
+	testPointToPoint(startPos: Vector3Mp, endPos: Vector3Mp, ignoreEntity?: EntityMp, flags?: number): RaycastResult;
+	testCapsule(startPos: Vector3Mp, endPos: Vector3Mp, radius: number, ignoreEntity?: EntityMp, flags?: number[]): RaycastResult;
 }
 
 interface StorageMp {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1173,7 +1173,7 @@ interface VehicleMp extends EntityMp {
 	getLandingGearState(): number;
 	getLastPedInSeat(seatIndex: number): Handle;
 	getLayoutHash(): Hash;
-	getLightsState(lightsOn: boolean, highbeamsOn: boolean): {
+	getLightsState(lightsOn: number, highbeamsOn: number): {
 		lightsOn: boolean;
 		highbeamsOn: boolean;
 	};


### PR DESCRIPTION
- fixed wrong parameters types in getLightsState (lightsOn, highbeamsOn)
- fixed wrong parameters types in testPointToPoint (ignoreEntity)
- fixed wrong parameters types in testCapsule (ignoreEntity)