### PR TITLE
v2: missing browser/game methods

### DIFF
--- a/game.d.ts
+++ b/game.d.ts
@@ -16,6 +16,7 @@
 /// <reference path="game/hud.d.ts" />
 /// <reference path="game/interior.d.ts" />
 /// <reference path="game/itemset.d.ts" />
+/// <reference path="game/legacy.d.ts" />
 /// <reference path="game/loadingscreen.d.ts" />
 /// <reference path="game/localization.d.ts" />
 /// <reference path="game/misc.d.ts" />

--- a/game/graphics.d.ts
+++ b/game/graphics.d.ts
@@ -311,7 +311,7 @@ interface GameGraphicsLegacy {
 	 * p12 defaults to 0
 	 * p13 defaults to 0
 	 * p14 defaults to 0
-	 * p15 defaults to 15
+	 * p15 defaults to 0
 	 *
 	 * Hash: 0x6F60E89A7B64EE1D - [NativeDB Reference](https://alloc8or.re/gta5/nativedb/?n=0x6F60E89A7B64EE1D)
 	 */

--- a/index.d.ts
+++ b/index.d.ts
@@ -49,6 +49,7 @@ interface Mp {
 	voiceChat: VoiceChatMp;
 
 	Blip: typeof BlipMp;
+	Browser: typeof BrowserMp;
 	Camera: typeof CameraMp;
 	Checkpoint: typeof CheckpointMp;
 	DummyEntity: typeof DummyEntityMp;
@@ -1477,13 +1478,15 @@ declare abstract class BrowserMp {
 	active: boolean;
 	url: string;
 
+	call(eventName: string, ...args: any[]): void;
+	callProc<T = any>(procName: string, ...args: any[]): Promise<T>;
+	cancelPendingProc(procName: string): void;
 	destroy(): void;
 	execute(code: string): void;
+	executeCached(code: string): void;
+	hasPendingProc(procName: string): boolean;
 	markAsChat(): void;
 	reload(ignoreCache: boolean): void;
-	call(eventName: string, ...args: any[]): void;
-	callProc(procName: string, ...args: any[]): Promise<any>;
-	executeCached(code: string): void;
 }
 
 declare abstract class CameraMp {
@@ -1787,11 +1790,11 @@ interface EventMpPool {
 	addProc(procName: string, callback: (...args: any[]) => void): void;
 	addProc(procs: ({ [name: string]: (...args: any[]) => void; })): void;
 	call(eventName: string, ...args: any[]): void;
-	callRemoteProc(procName: string, ...args: any[]): Promise<any>;
+	callRemoteProc<T = any>(procName: string, ...args: any[]): Promise<T>;
 	callRemoteUnreliable(eventName: string, ...args: any[]): void;
 	callRemote(eventName: string, ...args: any[]): void;
-	cancelPendingRpc(procName?: string): void;
-	hasPendingRpc(procName?: string): boolean;
+	cancelPendingProc(procName: string): void;
+	hasPendingProc(procName: string): boolean;
 	remove(eventName: string, handler?: (...args: any[]) => void): void;
 	remove(eventNames: string[]): void;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@types/ragemp-c",
-	"version": "2.0.3",
+	"version": "2.1.0",
 	"author": "CocaColaBear",
 	"description": "Rage:MP TypeScript type definition for Clientside",
 	"license": "MIT",


### PR DESCRIPTION
This adds to the work done in https://github.com/CocaColaBear/types-ragemp-c/pull/85. The types also now reference the legacy types (which need to be done manually after type generation).